### PR TITLE
Bump libSE to v3.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![travis](https://app.travis-ci.com/GerardSoleCa/katsuben.svg?branch=master) [![Maintainability](https://api.codeclimate.com/v1/badges/237f9d502add4c35d2a2/maintainability)](https://codeclimate.com/github/GerardSoleCa/katsuben/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/237f9d502add4c35d2a2/test_coverage)](https://codeclimate.com/github/GerardSoleCa/katsuben/test_coverage)
+
 # Katsuben
 
 Benshi (弁士) were Japanese performers who provided live narration for silent films (both Japanese films and Western

--- a/katsuben.unittests/SubtitleLoaderTests.cs
+++ b/katsuben.unittests/SubtitleLoaderTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.IO;
-using Nikse.SubtitleEdit.Core;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Xunit;
 

--- a/katsuben/SubtitleConverter.cs
+++ b/katsuben/SubtitleConverter.cs
@@ -1,6 +1,6 @@
 using System;
 using System.IO;
-using Nikse.SubtitleEdit.Core;
+using Nikse.SubtitleEdit.Core.Common;
 
 namespace Katsuben
 {

--- a/katsuben/SubtitleFormatFinder.cs
+++ b/katsuben/SubtitleFormatFinder.cs
@@ -1,5 +1,5 @@
 using System;
-using Nikse.SubtitleEdit.Core;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 
 namespace Katsuben

--- a/katsuben/SubtitleLoader.cs
+++ b/katsuben/SubtitleLoader.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Text;
-using Nikse.SubtitleEdit.Core;
+using Nikse.SubtitleEdit.Core.Common;
 
 namespace Katsuben
 {

--- a/katsuben/katsuben.csproj
+++ b/katsuben/katsuben.csproj
@@ -7,11 +7,13 @@
     <RootNamespace>Katsuben</RootNamespace>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TargetFramework>net5.0</TargetFramework>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="libse" Version="3.5.8" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
+    <PackageReference Include="libse" Version="3.6.2" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Update libSE to the latest version.
It adds support for TTML with "123456f" format time codes.